### PR TITLE
Add manual Fly deploy workflow

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to Fly.io
+
+on:
+  workflow_dispatch:
+    inputs:
+      bot_version:
+        description: Bot version shown by the frontend and webhook embeds
+        required: false
+        default: 1.0.4
+
+jobs:
+  deploy:
+    name: Deploy Go runtime
+    runs-on: ubuntu-latest
+    environment: hidedbot
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          BOT_VERSION: ${{ inputs.bot_version }}
+        run: flyctl deploy --remote-only --build-arg "VITE_BOT_VERSION=${BOT_VERSION}"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@
 2. run Go tests.
 3. build the Go server binary in the Docker multi-stage build.
 4. package the Vite `dist/` output and local `thumbs/` assets into the runtime image.
-5. deploy to Fly.io with `DC_WEBHOOK_URL` and `MONGO_URI` configured as secrets.
+5. deploy to Fly.io with the `Deploy to Fly.io` GitHub Actions workflow or `./build&deploy.sh` on a Fly-authenticated machine.
+
+Fly deployment requires Fly app secrets for `MONGO_URI` and either `DC_WEBHOOK_URL` or `DISCORD_TARGETS`. The GitHub Actions path also requires a `FLY_API_TOKEN` secret in the `hidedbot` environment.
 
 The Go version is the primary production runtime on `go-port`. The Java/Spring Boot code remains in `src/` as the legacy maintenance path.
 

--- a/docs/go-port/DEPLOYMENT_RUNBOOK.md
+++ b/docs/go-port/DEPLOYMENT_RUNBOOK.md
@@ -54,10 +54,11 @@
 
 ## 5. 部署流程
 
-1. 確認 Fly secrets 已設定：`MONGO_URI`，以及 `DC_WEBHOOK_URL` 或 `DISCORD_TARGETS`；必要時設定 `HOST_URL`、`MONGO_DATABASE`。
-2. 設定版本：`export BOT_VERSION=1.0.4`。
-3. 執行 `./build&deploy.sh`。
-4. 部署後檢查 `/actuator/health`、首頁、`/HideBot/discord/version` 與 `/HideBot/discord/targets`。
+1. 確認 Fly app secrets 已設定：`MONGO_URI`，以及 `DC_WEBHOOK_URL` 或 `DISCORD_TARGETS`；必要時設定 `HOST_URL`、`MONGO_DATABASE`。
+2. 在 GitHub environment `hidedbot` 設定 Actions secret `FLY_API_TOKEN`。
+3. 到 GitHub Actions 手動執行 `Deploy to Fly.io` workflow，輸入要顯示的 `bot_version`，預設為 `1.0.4`。
+4. 若在已登入 Fly CLI 的本機部署，設定版本：`export BOT_VERSION=1.0.4`，再執行 `./build&deploy.sh`。
+5. 部署後檢查 `/actuator/health`、首頁、`/HideBot/discord/version` 與 `/HideBot/discord/targets`。
 
 ## 6. 觀察項目
 


### PR DESCRIPTION
## Summary
- Add a manual `Deploy to Fly.io` GitHub Actions workflow for the Go production runtime.
- Use the existing `hidedbot` environment and require `FLY_API_TOKEN` as an Actions secret.
- Document the Actions deploy path beside the local Fly CLI deploy path.

## Verification
- `rtk ruby -e 'require "yaml"; YAML.load_file(".github/workflows/fly-deploy.yml"); puts "yaml ok"'`\n- `rtk git diff HEAD~1..HEAD --check`\n\n## Deployment note\nThe repo currently has no `FLY_API_TOKEN` secret listed and local `fly auth whoami` fails, so this workflow enables deployment once that token is added but cannot perform the production deploy yet.