### PR TITLE
Document Java legacy branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 Fly deployment requires Fly app secrets for `MONGO_URI` and either `DC_WEBHOOK_URL` or `DISCORD_TARGETS`. The GitHub Actions path also requires a `FLY_API_TOKEN` secret in the `hidedbot` environment.
 
-The Go version is the primary production runtime on `go-port`. The Java/Spring Boot code remains in `src/` as the legacy maintenance path.
+The Go version is the primary production runtime on `master`. The Java/Spring Boot runtime is preserved on the `legacy-java` branch for legacy maintenance, and the Java source still remains in `src/` on `master` for reference and compatibility work.
 
 ## Discord targets
 

--- a/docs/go-port/DEPLOYMENT_RUNBOOK.md
+++ b/docs/go-port/DEPLOYMENT_RUNBOOK.md
@@ -50,6 +50,7 @@
 - 單 binary 啟動
 - 映像檔應使用 multi-stage build
 - production runtime 使用 Go binary；Java/Spring Boot 程式碼保留為 legacy 維護路徑，不參與 Fly production deploy
+- Java legacy runtime 維護分支為 `legacy-java`；`master` 以 Go runtime 為主線
 - Docker build 會把 `web/dist` 複製成 runtime `STATIC_DIR`，並保留 `/thumbs/*` 本地縮圖資產
 
 ## 5. 部署流程

--- a/docs/go-port/README.md
+++ b/docs/go-port/README.md
@@ -1,6 +1,6 @@
 # Go Port Documentation Set
 
-本目錄收錄 `go-port` 分支的 Go 版本移植文件。
+本目錄收錄 Go 版本移植文件。Go runtime 現在是 `master` 的主要 production runtime；Java/Spring Boot legacy runtime 保留在 `legacy-java` 分支維護。
 
 ## 文件清單
 


### PR DESCRIPTION
## Summary
- Document `master` as the Go production line.
- Document `legacy-java` as the Java/Spring Boot maintenance branch.

## Verification
- `rtk git diff --cached --check` before commit
